### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Deodorant is a Bayesian optimization package with three core features:
 1. Domain scaling to exploit problem independent GP hyperpriors
 2. A non-stationary mean function to allow unbounded optimization
 3. External provision of the acquisition function optimizer so that this can incorporate the constraints of the problem (inc equality constraints) and ensure that no invalid points are evaluated.
-\end{enumerate}
 
 The main intended use of the package at present is as the BO component for [BOPP](https://github.com/probprog/bopp):
 


### PR DESCRIPTION
Just removed a hanging enumerate statement from the README.